### PR TITLE
fix(DataGrid): Row size change issues with virtual scrolling enabled

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridVirtualBody.tsx
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridVirtualBody.tsx
@@ -66,7 +66,7 @@ const DatagridVirtualBody = (datagridState: DataGridState) => {
     if (listRef && listRef.current) {
       listRef.current.resetAfterIndex(0);
     }
-  }, [listRef]);
+  }, [listRef,rowHeight]);
 
   const visibleRows = ((DatagridPagination && page) || rows) as DatagridRow[];
   const testRef: MutableRefObject<HTMLDivElement | null> = useRef(null);


### PR DESCRIPTION


Closes #5768

call `resetAfterIndex()` when there is a row height change that will reset the cache of `react-window`


#### How did you test and verify your work?
storybook